### PR TITLE
Fix double namespacing

### DIFF
--- a/lib/iLocalStorage.js
+++ b/lib/iLocalStorage.js
@@ -139,7 +139,9 @@
         if (this.namespace) {
             this.keys().filter(function (key) {
                 return key.substr(0, that.namespace.length) === that.namespace;
-            }).forEach(this.removeItem);
+            }).forEach(function (key) {
+              that.storage.removeItem(key);
+            });
         } else {
             return this.maybeSwallowException(function () {
                 this.storage.clear();

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "author": "Gustav Nikolaj Olsen <gustavnikolaj@gmail.com>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "mocha": "1.18.2",
-    "mocha-phantomjs": "3.3.2",
-    "phantomjs": "1.9.7-3",
-    "sinon": "1.9.1",
-    "unexpected": "3.1.4",
-    "unexpected-sinon": "3.0.1"
+    "mocha": "2.4.5",
+    "mocha-phantomjs": "4.0.2",
+    "phantomjs": "2.1.3",
+    "sinon": "1.17.3",
+    "unexpected": "10.8.2",
+    "unexpected-sinon": "10.1.1"
   },
   "repository": "https://github.com/gustavnikolaj/ilocalstorage"
 }

--- a/test/iLocalStorage.spec.js
+++ b/test/iLocalStorage.spec.js
@@ -208,15 +208,15 @@ describe('iLocalStorage', function () {
         });
         describe('clear', function () {
             it('should remove all keys in the defined namespace', function () {
-                fakeObj.removeItem = sinon.spy();
                 fakeObj.keys = function () { return Object.keys(this.storage); };
                 fakeObj.storage = {
                     'test.foo': 'foo',
                     'bar': 'foo'
                 };
+                fakeObj.storage.removeItem = sinon.spy();
                 iLocalStorage.prototype.clear.call(fakeObj);
-                expect(fakeObj.removeItem, 'was called once');
-                expect(fakeObj.removeItem, 'was called with', 'test.foo');
+                expect(fakeObj.storage.removeItem, 'was called once');
+                expect(fakeObj.storage.removeItem, 'was called with', 'test.foo');
             });
             it('should remove all keys when not given a namespace', function () {
                 fakeObj.storage = {


### PR DESCRIPTION
Clearing a namespaced store was double namespacing when calling the `removeItem`. This fix calls the `storage.removeItem` so it does not namespace again.

I have updated all dev dependencies, since phantomjs was failing (http://cdn.bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip) and went ahead and updated the rest.
